### PR TITLE
Fix broken url to "Better Bloom Filter" paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ func main() {
 
 [1]: http://en.wikipedia.org/wiki/Bloom_filter
 [2]: http://astrometry.net/svn/trunk/documents/papers/dstn-review/papers/bloom1970.pdf
-[3]: http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf
+[3]: https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf
 [4]: http://spyced.blogspot.com/2009/01/all-you-ever-wanted-to-know-about.html
 [5]: https://godoc.org/github.com/turgon/bloom


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author